### PR TITLE
do not attempt to manage running user if it is root

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 prometheus_node_exporter_version: 0.15.2
 prometheus_node_exporter_download_url: https://github.com/prometheus/node_exporter/releases/download/v{{ prometheus_node_exporter_version }}/node_exporter-{{ prometheus_node_exporter_version }}.linux-amd64.tar.gz
+prometheus_node_exporter_manage_user: True
 prometheus_node_exporter_service_username: node-exp
 prometheus_node_exporter_service_group: node-exp
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
     groups: "{{ prometheus_node_exporter_service_group }}"
     append: yes
     shell: /bin/bash
+  when: prometheus_node_exporter_service_username != 'root'
 
 #
 # Install Prometheus Node Exporter

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
     groups: "{{ prometheus_node_exporter_service_group }}"
     append: yes
     shell: /bin/bash
-  when: prometheus_node_exporter_service_username != 'root'
+  when: prometheus_node_exporter_manage_user == True
 
 #
 # Install Prometheus Node Exporter


### PR DESCRIPTION
Though it is bad practice, you sometimes need to run as root to avoid tons of issues with node exporter trying to access for example Docker namespace.

In this case, setting the user to root is necessary, but most often it is already managed elsewhere